### PR TITLE
docs: add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,4 +4,4 @@
 
 
 # DevOps
-* @devops
+* @southernlights-tech/devops


### PR DESCRIPTION
## Description

This PR updates the `CODEOWNERS` file to reflect the new GitHub team slug for the DevOps team. The alias has been changed from `@devops` to `@southernlights-tech/devops`.
